### PR TITLE
Remove Zenoh prefix functionality from all applications

### DIFF
--- a/configurator/src/configurator/config.py
+++ b/configurator/src/configurator/config.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field, model_validator
 class GlobalConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
-    zenoh_prefix: str = Field(default="", description="Zenohのプレフィックス")
     websocket_port: int = Field(
         default=8080, gt=0, le=65535, description="WebSocketのポート番号"
     )

--- a/configurator/test/resources/config_sample.toml
+++ b/configurator/test/resources/config_sample.toml
@@ -2,7 +2,6 @@
 
 [global]
 websocket_port = 8080
-zenoh_prefix = ""
 
 [gui]
 # WebSocketのホスト

--- a/configurator/test/resources/global_config_zenoh_prefix.toml
+++ b/configurator/test/resources/global_config_zenoh_prefix.toml
@@ -1,2 +1,0 @@
-[global]
-zenoh_prefix = "roboapp"

--- a/configurator/test/test_config_parse.py
+++ b/configurator/test/test_config_parse.py
@@ -62,16 +62,6 @@ def test_global_config_websocket_port(get_resource_path: Path) -> None:
         config = Config.model_validate(tomllib.load(f))
     assert config.global_ is not None
     assert config.global_.websocket_port == 9090
-    assert config.global_.zenoh_prefix == ""
-
-
-def test_global_config_zenoh_prefix(get_resource_path: Path) -> None:
-    config_file = get_resource_path / "global_config_zenoh_prefix.toml"
-    with open(config_file, "rb") as f:
-        config = Config.model_validate(tomllib.load(f))
-    assert config.global_ is not None
-    assert config.global_.zenoh_prefix == "roboapp"
-    assert config.global_.websocket_port == 8080
 
 
 def test_gui_config_host(get_resource_path: Path) -> None:

--- a/lidar_system/include/config.hpp
+++ b/lidar_system/include/config.hpp
@@ -10,16 +10,12 @@
 
 class GlobalConfig {
  public:
-  std::string zenoh_prefix = "";
   uint16_t websocket_port = 8080;
 
   GlobalConfig() = default;
   GlobalConfig(toml::value toml_config) {
     if (toml_config.contains("global")) {
       auto global_config = toml_config.at("global");
-      if (global_config.contains("zenoh_prefix")) {
-        zenoh_prefix = toml::find<std::string>(global_config, "zenoh_prefix");
-      }
       if (global_config.contains("websocket_port")) {
         websocket_port =
             toml::get<uint16_t>(global_config.at("websocket_port"));

--- a/lidar_system/src/processor.cpp
+++ b/lidar_system/src/processor.cpp
@@ -48,17 +48,12 @@ int main(int argc, char **argv) {
       lidar_config_all.repulsive_gain, lidar_config_all.influence_range);
 
   // Zenoh Setup
-  auto prefix = global_config.zenoh_prefix;
-  if (!prefix.empty() && prefix.back() != '/') {
-    prefix += "/";
-  }
-
   auto zenoh_config = zenoh::Config::create_default();
   zenoh_config.insert_json5(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");
 
   auto session = zenoh::Session(std::move(zenoh_config));
-  session.declare_background_subscriber(      //
-      zenoh::KeyExpr(prefix + "lidar/data"),  //
+  session.declare_background_subscriber(  //
+      zenoh::KeyExpr("lidar/data"),       //
       [&timestamps, &updated](const zenoh::Sample &sample) {
         auto timestamp = ntp64_to_timepoint(sample.get_timestamp()->get_time());
 
@@ -76,7 +71,7 @@ int main(int argc, char **argv) {
       zenoh::closures::none);
 
   auto vec_publisher =
-      session.declare_publisher(zenoh::KeyExpr(prefix + "lidar/force_vector"));
+      session.declare_publisher(zenoh::KeyExpr("lidar/force_vector"));
 
   while (true) {
     auto now = std::chrono::system_clock::now();

--- a/lidar_system/src/sender.cpp
+++ b/lidar_system/src/sender.cpp
@@ -57,17 +57,12 @@ int main(int argc, char* argv[]) {
   }
 
   // Zenoh Setup
-  auto prefix = global_config.zenoh_prefix;
-  if (!prefix.empty() && prefix.back() != '/') {
-    prefix += "/";
-  }
-
   auto config = zenoh::Config::create_default();
   config.insert_json5(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");
 
   auto session = zenoh::Session(std::move(config));
   auto publisher = session.declare_publisher(  //
-      zenoh::KeyExpr(prefix + "lidar/data"));
+      zenoh::KeyExpr("lidar/data"));
 
   auto data = LiDARDataWrapper(lidar_config.x, lidar_config.y);
 

--- a/lidar_system/src/viewer.cpp
+++ b/lidar_system/src/viewer.cpp
@@ -70,8 +70,8 @@ int main(int argc, char **argv) {
       },
       zenoh::closures::none);
 
-  session.declare_background_subscriber(          //
-      zenoh::KeyExpr("lidar/force_vector"),       //
+  session.declare_background_subscriber(     //
+      zenoh::KeyExpr("lidar/force_vector"),  //
       [&vec, &updated](const zenoh::Sample &sample) {
         auto timestamp = ntp64_to_timepoint(sample.get_timestamp()->get_time());
 

--- a/lidar_system/src/viewer.cpp
+++ b/lidar_system/src/viewer.cpp
@@ -48,17 +48,12 @@ int main(int argc, char **argv) {
   auto visualizer = Visualizer(lidar_config_all, 600);
 
   // Zenoh Setup
-  auto prefix = global_config.zenoh_prefix;
-  if (!prefix.empty() && prefix.back() != '/') {
-    prefix += "/";
-  }
-
   auto zenoh_config = zenoh::Config::create_default();
   zenoh_config.insert_json5(Z_CONFIG_ADD_TIMESTAMP_KEY, "true");
 
   auto session = zenoh::Session(std::move(zenoh_config));
-  session.declare_background_subscriber(      //
-      zenoh::KeyExpr(prefix + "lidar/data"),  //
+  session.declare_background_subscriber(  //
+      zenoh::KeyExpr("lidar/data"),       //
       [&lidar_timestamps, &updated](const zenoh::Sample &sample) {
         auto timestamp = ntp64_to_timepoint(sample.get_timestamp()->get_time());
 
@@ -75,8 +70,8 @@ int main(int argc, char **argv) {
       },
       zenoh::closures::none);
 
-  session.declare_background_subscriber(              //
-      zenoh::KeyExpr(prefix + "lidar/force_vector"),  //
+  session.declare_background_subscriber(          //
+      zenoh::KeyExpr("lidar/force_vector"),       //
       [&vec, &updated](const zenoh::Sample &sample) {
         auto timestamp = ntp64_to_timepoint(sample.get_timestamp()->get_time());
 

--- a/lidar_system/test/resources/global_config_zenoh_prefix.toml
+++ b/lidar_system/test/resources/global_config_zenoh_prefix.toml
@@ -1,1 +1,0 @@
-../../../configurator/test/resources/global_config_zenoh_prefix.toml

--- a/lidar_system/test/test_config.cpp
+++ b/lidar_system/test/test_config.cpp
@@ -7,7 +7,6 @@ TEST(ConfigTest, LoadEmptyConfigFile) {
   auto root = get_config_file("../test/resources/global_config_empty.toml");
   auto config = GlobalConfig(root);
 
-  EXPECT_EQ(config.zenoh_prefix, "");
   EXPECT_EQ(config.websocket_port, 8080);
 }
 
@@ -16,17 +15,7 @@ TEST(ConfigTest, LoadWebsocketPortFromToml) {
       get_config_file("../test/resources/global_config_websocket_port.toml");
   auto config = GlobalConfig(root);
 
-  EXPECT_EQ(config.zenoh_prefix, "");
   EXPECT_EQ(config.websocket_port, 9090);
-}
-
-TEST(ConfigTest, LoadZenohPrefixFromToml) {
-  auto root =
-      get_config_file("../test/resources/global_config_zenoh_prefix.toml");
-  auto config = GlobalConfig(root);
-
-  EXPECT_EQ(config.zenoh_prefix, std::optional<std::string>("roboapp"));
-  EXPECT_EQ(config.websocket_port, 8080);
 }
 
 // LiDAR Config

--- a/main_camera_system/src/config.rs
+++ b/main_camera_system/src/config.rs
@@ -24,15 +24,12 @@ fn parse_configpath(path: Option<PathBuf>) -> PathBuf {
 pub struct GlobalConfig {
     #[serde(default = "GlobalConfig::default_websocket_port")]
     pub websocket_port: u16,
-    #[serde(default = "GlobalConfig::default_zenoh_prefix")]
-    pub zenoh_prefix: String,
 }
 
 impl Default for GlobalConfig {
     fn default() -> Self {
         Self {
             websocket_port: Self::default_websocket_port(),
-            zenoh_prefix: Self::default_zenoh_prefix(),
         }
     }
 }
@@ -40,9 +37,6 @@ impl Default for GlobalConfig {
 impl GlobalConfig {
     fn default_websocket_port() -> u16 {
         8080
-    }
-    fn default_zenoh_prefix() -> String {
-        "".to_string()
     }
 }
 

--- a/main_camera_system/src/main.rs
+++ b/main_camera_system/src/main.rs
@@ -59,14 +59,8 @@ async fn main() {
 
     let zenoh = zenoh::open(zenoh_config).await.unwrap();
 
-    let prefix: String = if global_config.zenoh_prefix.is_empty() {
-        "".to_string()
-    } else {
-        format!("{}/", global_config.zenoh_prefix)
-    };
-
     let jpg_publisher: Option<zenoh::pubsub::Publisher> = if camera_config.zenoh {
-        let topic_name = format!("{prefix}cam/jpg");
+        let topic_name = "cam/jpg";
         info!("JPEG publishing enabled at {topic_name}");
         Some(zenoh.declare_publisher(topic_name).await.unwrap())
     } else {
@@ -74,7 +68,7 @@ async fn main() {
     };
 
     let subscriber = zenoh
-        .declare_subscriber(format!("{}cam/switch", prefix))
+        .declare_subscriber("cam/switch")
         .await
         .unwrap();
 

--- a/main_camera_system/src/main.rs
+++ b/main_camera_system/src/main.rs
@@ -67,10 +67,7 @@ async fn main() {
         None
     };
 
-    let subscriber = zenoh
-        .declare_subscriber("cam/switch")
-        .await
-        .unwrap();
+    let subscriber = zenoh.declare_subscriber("cam/switch").await.unwrap();
 
     // WebSocket配信を有効化する場合のみサーバーを起動
     type WsClients = Arc<Mutex<Vec<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>>>;

--- a/main_camera_system/test/resources/global_config_zenoh_prefix.toml
+++ b/main_camera_system/test/resources/global_config_zenoh_prefix.toml
@@ -1,1 +1,0 @@
-../../../configurator/test/resources/global_config_zenoh_prefix.toml

--- a/uart_bridge/src/uart_bridge/domain/config.py
+++ b/uart_bridge/src/uart_bridge/domain/config.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel, Field, field_validator
 
 
 class GlobalConfig(BaseModel):
-    zenoh_prefix: str = Field(default="", description="Zenoh Prefix")
     websocket_port: int = Field(default=8080, description="WebSocket Port")
 
 

--- a/uart_bridge/src/uart_bridge/infra/zenoh_transmitter.py
+++ b/uart_bridge/src/uart_bridge/infra/zenoh_transmitter.py
@@ -26,9 +26,7 @@ class ZenohTransmitter(Transmitter):
             "cam/switch"
         )
 
-        self.publishers["disks"] = self.zenoh_session.declare_publisher(
-            "disks"
-        )
+        self.publishers["disks"] = self.zenoh_session.declare_publisher("disks")
 
         self.publishers["flap"] = self.zenoh_session.declare_publisher("flap")
 

--- a/uart_bridge/src/uart_bridge/infra/zenoh_transmitter.py
+++ b/uart_bridge/src/uart_bridge/infra/zenoh_transmitter.py
@@ -14,13 +14,8 @@ from uart_bridge.domain.transmitter_messages import (
 class ZenohTransmitter(Transmitter):
     """Transmits data using Zenoh protocol."""
 
-    def __init__(self, prefix: str = "") -> None:
+    def __init__(self) -> None:
         self.zenoh_session = zenoh.open(zenoh.Config())
-
-        if prefix:
-            prefix = prefix.rstrip("/") + "/"
-        else:
-            prefix = ""
 
         self.publishers = {}
 
@@ -28,17 +23,17 @@ class ZenohTransmitter(Transmitter):
         self.robot_state = RobotState()
 
         self.publishers["cam/switch"] = self.zenoh_session.declare_publisher(
-            f"{prefix}cam/switch"
+            "cam/switch"
         )
 
         self.publishers["disks"] = self.zenoh_session.declare_publisher(
-            f"{prefix}disks"
+            "disks"
         )
 
-        self.publishers["flap"] = self.zenoh_session.declare_publisher(f"{prefix}flap")
+        self.publishers["flap"] = self.zenoh_session.declare_publisher("flap")
 
         self.zenoh_session.declare_subscriber(
-            f"{prefix}lidar/force_vector",
+            "lidar/force_vector",
             self.lidar_subscriber,
         )
 

--- a/uart_bridge/src/uart_bridge/main.py
+++ b/uart_bridge/src/uart_bridge/main.py
@@ -21,12 +21,11 @@ def parse_args() -> argparse.Namespace:
 
 def run_application(
     robot_port: str,
-    zenoh_prefix: str = "",
 ) -> None:
     """アプリケーションを実行する"""
     with (
         SerialRobotDriver(robot_port) as robot_driver,
-        ZenohTransmitter(prefix=zenoh_prefix) as transmitter,
+        ZenohTransmitter() as transmitter,
     ):
         app = Application(robot_driver, transmitter)
         app.spin()
@@ -42,7 +41,6 @@ def main() -> None:
 
     run_application(
         robot_port=config.uart.device,
-        zenoh_prefix=config.global_.zenoh_prefix,
     )
 
 

--- a/uart_bridge/test/domain/test_config.py
+++ b/uart_bridge/test/domain/test_config.py
@@ -17,7 +17,6 @@ def test_read_empty_global_config(get_resource_path: Path) -> None:
     config_file = get_resource_path / "empty.toml"
     c = load_and_parse_config(config_file).global_
 
-    assert c.zenoh_prefix == ""
     assert c.websocket_port == 8080
 
 
@@ -33,17 +32,7 @@ def test_read_global_config_websocket_port(get_resource_path: Path) -> None:
 
     c = load_and_parse_config(config_file).global_
 
-    assert c.zenoh_prefix == ""
     assert c.websocket_port == 9090
-
-
-def test_read_global_config_zenoh_prefix(get_resource_path: Path) -> None:
-    config_file = get_resource_path / "global_config_zenoh_prefix.toml"
-
-    c = load_and_parse_config(config_file).global_
-
-    assert c.zenoh_prefix == "roboapp"
-    assert c.websocket_port == 8080
 
 
 def test_read_uart_config_with_not_exist(get_resource_path: Path) -> None:

--- a/uart_bridge/test/resources/global_config_zenoh_prefix.toml
+++ b/uart_bridge/test/resources/global_config_zenoh_prefix.toml
@@ -1,1 +1,0 @@
-../../../configurator/test/resources/global_config_zenoh_prefix.toml

--- a/ui_system/src-tauri/src/config.rs
+++ b/ui_system/src-tauri/src/config.rs
@@ -24,15 +24,12 @@ fn get_config_file(file_path: Option<&str>) -> PathBuf {
 pub struct GlobalConfig {
     #[serde(default = "GlobalConfig::default_websocket_port")]
     pub websocket_port: u16,
-    #[serde(default = "GlobalConfig::default_zenoh_prefix")]
-    pub zenoh_prefix: String,
 }
 
 impl Default for GlobalConfig {
     fn default() -> Self {
         Self {
             websocket_port: Self::default_websocket_port(),
-            zenoh_prefix: Self::default_zenoh_prefix(),
         }
     }
 }
@@ -40,9 +37,6 @@ impl Default for GlobalConfig {
 impl GlobalConfig {
     fn default_websocket_port() -> u16 {
         8080
-    }
-    fn default_zenoh_prefix() -> String {
-        "".to_string()
     }
 }
 
@@ -91,17 +85,6 @@ mod tests {
             .global;
 
         assert_eq!(g.websocket_port, 8080);
-        assert_eq!(g.zenoh_prefix, "");
-    }
-
-    #[test]
-    fn test_parse_globalconfig_zenoh_prefix() {
-        let g = load_config(Some("test/resources/global_config_zenoh_prefix.toml"))
-            .unwrap()
-            .global;
-
-        assert_eq!(g.websocket_port, 8080);
-        assert_eq!(g.zenoh_prefix, "roboapp".to_string());
     }
 
     #[test]
@@ -111,7 +94,6 @@ mod tests {
             .global;
 
         assert_eq!(g.websocket_port, 9090);
-        assert_eq!(g.zenoh_prefix, "");
     }
 
     #[test]

--- a/ui_system/src-tauri/src/lib.rs
+++ b/ui_system/src-tauri/src/lib.rs
@@ -52,7 +52,6 @@ pub fn run() {
             let mut global_config_lock = state_global_config.lock().unwrap();
             let mut gui_config_lock = state_gui_config.lock().unwrap();
 
-            global_config_lock.zenoh_prefix = global_config.zenoh_prefix.clone();
             global_config_lock.websocket_port = global_config.websocket_port;
 
             gui_config_lock.host = gui_config.host.clone();
@@ -60,7 +59,7 @@ pub fn run() {
             let app_handle = app.app_handle().clone();
 
             tauri::async_runtime::spawn(async move {
-                zenoh_sub(app_handle, global_config.zenoh_prefix).await;
+                zenoh_sub(app_handle).await;
             });
 
             Ok(())
@@ -72,12 +71,11 @@ pub fn run() {
 async fn declare_and_emit(
     session: &zenoh::Session,
     app: Arc<AppHandle>,
-    prefix: &str,
     event_name: &str,
 ) {
     let event_name_cloned = event_name.to_string();
     session
-        .declare_subscriber(format!("{prefix}{event_name}"))
+        .declare_subscriber(event_name)
         .callback_mut(move |sample| {
             app.emit(
                 &event_name_cloned,
@@ -107,26 +105,20 @@ fn get_config_port(global_config: State<'_, Mutex<config::GlobalConfig>>) -> Res
     Ok(global_config.lock().unwrap().websocket_port)
 }
 
-async fn zenoh_sub(app: AppHandle, prefix: String) {
+async fn zenoh_sub(app: AppHandle) {
     zenoh::init_log_from_env_or("error");
 
     let session = zenoh_client::create_zenoh_session();
 
     let app = Arc::new(app);
 
-    let prefix_slash = if prefix.is_empty() {
-        "".to_string()
-    } else {
-        format!("{prefix}/")
-    };
-    declare_and_emit(&session, Arc::clone(&app), &prefix_slash, "cam/switch").await;
-    declare_and_emit(&session, Arc::clone(&app), &prefix_slash, "damagepanel").await;
-    declare_and_emit(&session, Arc::clone(&app), &prefix_slash, "disks").await;
-    declare_and_emit(&session, Arc::clone(&app), &prefix_slash, "flap").await;
+    declare_and_emit(&session, Arc::clone(&app), "cam/switch").await;
+    declare_and_emit(&session, Arc::clone(&app), "damagepanel").await;
+    declare_and_emit(&session, Arc::clone(&app), "disks").await;
+    declare_and_emit(&session, Arc::clone(&app), "flap").await;
     declare_and_emit(
         &session,
         Arc::clone(&app),
-        &prefix_slash,
         "lidar/force_vector",
     )
     .await;

--- a/ui_system/src-tauri/src/lib.rs
+++ b/ui_system/src-tauri/src/lib.rs
@@ -68,11 +68,7 @@ pub fn run() {
         .expect("error while running tauri application");
 }
 
-async fn declare_and_emit(
-    session: &zenoh::Session,
-    app: Arc<AppHandle>,
-    event_name: &str,
-) {
+async fn declare_and_emit(session: &zenoh::Session, app: Arc<AppHandle>, event_name: &str) {
     let event_name_cloned = event_name.to_string();
     session
         .declare_subscriber(event_name)
@@ -116,12 +112,7 @@ async fn zenoh_sub(app: AppHandle) {
     declare_and_emit(&session, Arc::clone(&app), "damagepanel").await;
     declare_and_emit(&session, Arc::clone(&app), "disks").await;
     declare_and_emit(&session, Arc::clone(&app), "flap").await;
-    declare_and_emit(
-        &session,
-        Arc::clone(&app),
-        "lidar/force_vector",
-    )
-    .await;
+    declare_and_emit(&session, Arc::clone(&app), "lidar/force_vector").await;
 
     loop {
         tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;

--- a/ui_system/src-tauri/test/resources/global_config_zenoh_prefix.toml
+++ b/ui_system/src-tauri/test/resources/global_config_zenoh_prefix.toml
@@ -1,1 +1,0 @@
-../../../../configurator/test/resources/global_config_zenoh_prefix.toml


### PR DESCRIPTION
Deleted `zenoh_prefix` configuration and its usage from:
- lidar_system (C++)
- uart_bridge (Python)
- ui_system (Rust/Tauri)
- main_camera_system (Rust)
- configurator (Python)

Updated tests and removed obsolete test resources.