### PR TITLE
UARTのポート解決を修正

### DIFF
--- a/uart_bridge/src/uart_bridge/domain/config.py
+++ b/uart_bridge/src/uart_bridge/domain/config.py
@@ -30,15 +30,6 @@ def get_dummy_port() -> tuple[Path, Path]:
 class UartConfig(BaseModel):
     device: str = Field(str(get_dummy_port()[1]), description="UARTポートのパス")
 
-    @field_validator("device", mode="after")
-    @classmethod
-    def validate_port(cls, v: str) -> str:
-        # ここで加工
-        real_path = Path(v).resolve()
-        if not real_path.exists():
-            raise ValueError(f"{v} is not a valid UART port!")
-        return str(real_path)
-
 
 class Config(BaseModel):
     uart: UartConfig | None = None

--- a/uart_bridge/src/uart_bridge/domain/config.py
+++ b/uart_bridge/src/uart_bridge/domain/config.py
@@ -4,7 +4,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 
 def get_dummy_port() -> tuple[Path, Path]:

--- a/uart_bridge/src/uart_bridge/infra/serial_robot_driver.py
+++ b/uart_bridge/src/uart_bridge/infra/serial_robot_driver.py
@@ -2,6 +2,7 @@ import logging
 import time
 from collections.abc import Sequence
 from copy import deepcopy
+from pathlib import Path
 from threading import Lock
 from typing import Any
 
@@ -56,7 +57,7 @@ class SerialRobotDriver(RobotDriver):
         """シリアルポートを開く"""
         try:
             self._serial = serial.Serial(
-                port=self._port.resolve(),
+                port=str(Path(self._port).resolve()),
                 baudrate=self._baudrate,
                 stopbits=self._stopbits,
                 parity=self._parity,

--- a/uart_bridge/src/uart_bridge/infra/serial_robot_driver.py
+++ b/uart_bridge/src/uart_bridge/infra/serial_robot_driver.py
@@ -56,7 +56,7 @@ class SerialRobotDriver(RobotDriver):
         """シリアルポートを開く"""
         try:
             self._serial = serial.Serial(
-                port=self._port,
+                port=self._port.resolve(),
                 baudrate=self._baudrate,
                 stopbits=self._stopbits,
                 parity=self._parity,

--- a/uart_bridge/test/domain/test_config.py
+++ b/uart_bridge/test/domain/test_config.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
 
 from uart_bridge.domain.config import (
     load_and_parse_config,
@@ -20,19 +19,7 @@ def test_read_empty_uart_config(get_resource_path: Path) -> None:
     assert config.uart is None
 
 
-def test_read_uart_config_with_not_exist(get_resource_path: Path) -> None:
-    config_file = get_resource_path / "uart_device.toml"
-
-    with pytest.raises(ValidationError):
-        load_and_parse_config(config_file)
-
-
 def test_read_uart_config(get_resource_path: Path) -> None:
-    p = Path("/tmp/roboapp_test_uart")
-
-    if not p.exists():
-        p.symlink_to("/dev/null")
-
     config_file = get_resource_path / "uart_device.toml"
 
     c = load_and_parse_config(config_file).uart
@@ -40,7 +27,5 @@ def test_read_uart_config(get_resource_path: Path) -> None:
     if c is None:
         pytest.fail("UART config should not be None")
 
-    assert c.device == "/dev/null"
-
-    if p.exists():
-        p.unlink()
+    # 設定ファイル(uart_device.toml)に記述された "/tmp/roboapp_test_uart" がそのまま読み込まれることを確認
+    assert c.device == "/tmp/roboapp_test_uart"


### PR DESCRIPTION
- **markdown linterを追加 (#30)**
- **actionlintとyamlfmtを入れる (#29)**
- **update gitignore**
- **起動化無効化**
- **systemdのtargetを変更 (#32)**
- **downgrade python (#33)**
- **zenohを1.6.2で固定する (#34)**
- **Remove Zenoh prefix functionality from all applications (#36)**
- **Update README.md for all applications with configuration details (#37)**
- **update type checking**
- **描画順を変更**
- **add derived**
- **pub sub exampleで、周波数を扱う (#38)**
- **update check rule**
- **Feature/adjust uartbridge performance (#39)**
- **Feature/ai acceleration (#40)**
- **CICDの高速化 (#43)**
- **add dummy firm (#46)**
- **Feature/robot state message (#44)**
- **Feature/lidar view (#45)**
- **Feature/zenohd router (#35)**
- **uart のバグを修正**
- **random algolithmを調整**
- **ダメージパネル側の型変更 (#31)**
- **Feature/lidar view 4 (#47)**
- **型境界チェックの強化 (#48)**
- **zenoh用のlidar型を分離する**
- **Update configurator/mise.toml**
- **Update lidar_system/include/visualizer/range_separater.hpp**
- **uart parseを強化**
- **callbackを修正**
- **型定義の修正**
- **global config・configuratorを削除 (#49)**
- **delte configurator on mise**
- **lidarのシングルバイナリ化 (#50)**
- **Feature/autostart (#52)**
- **protobufの導入 (#51)**
- **fix workflow**
- **カメラのリアーキ (#53)**
- **tauriの描画の軽量化 (#55)**
- **lidarの統合 (#56)**
- **ciの高速化テスト (#57)**
- **auto startからsenderを削除**
- **Dockerfileを軽量化**
- **文字を修正**
- **ws配信タスクを調整**
- **ログを減らす (#58)**
- **uartのパスを修正**
- **portのチェックを修正**
